### PR TITLE
Allow compatibility with codeception 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "codeception/codeception": "2.0.*"
+        "codeception/codeception": "2.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Currently one can't install this module with the latest Codeception 2.1. This PR should allow you to install.
